### PR TITLE
Add index type to sparse array

### DIFF
--- a/src/anndata.ts
+++ b/src/anndata.ts
@@ -2,10 +2,12 @@ import type { Readable } from "@zarrita/storage";
 import * as zarr from "zarrita";
 import type AxisArrays from "./axis_arrays.js";
 import type SparseArray from "./sparse_array.js";
-import type { AxisKeyTypes } from "./types.js";
+import type { AxisKeyTypes, IndexType } from "./types.js";
+
 export default class AnnData<
 	S extends Readable,
 	D extends zarr.NumberDataType,
+	I extends IndexType,
 > {
 	public obs: AxisArrays<S>;
 	public var: AxisArrays<S>;
@@ -13,10 +15,10 @@ export default class AnnData<
 	public obsp: AxisArrays<S>;
 	public varm: AxisArrays<S>;
 	public varp: AxisArrays<S>;
-	public X: SparseArray<D> | zarr.Array<D> | undefined;
+	public X: SparseArray<D, I, S> | zarr.Array<D> | undefined;
 	public layers: AxisArrays<S>;
 
-	constructor(data: AxisKeyTypes<S, D>) {
+	constructor(data: AxisKeyTypes<S, D, I>) {
 		this.obs = data.obs;
 		this.var = data.var;
 		this.obsm = data.obsm;

--- a/src/axis_arrays.ts
+++ b/src/axis_arrays.ts
@@ -8,7 +8,7 @@ import type { BackedArray } from "./types.js";
 export default class AxisArrays<S extends Readable> {
 	public parent: zarr.Group<S>;
 	public name: string;
-	private cache: Map<string, BackedArray>;
+	private cache: Map<string, BackedArray<S>>;
 
 	public constructor(parent: zarr.Group<S>, name: string) {
 		this.name = name;
@@ -20,7 +20,7 @@ export default class AxisArrays<S extends Readable> {
 		return await zarr.open(this.parent.resolve(this.name), { kind: "group" });
 	}
 
-	public async get(key: string): Promise<BackedArray> {
+	public async get(key: string): Promise<BackedArray<S>> {
 		if (!(await this.has(key))) {
 			throw new Error(`${this.name} has no key: \"${key}\"`);
 		}

--- a/src/io.ts
+++ b/src/io.ts
@@ -9,6 +9,7 @@ import {
 	type AxisKeyTypes,
 	AxisKeys,
 	type UIntType,
+	type IndexType,
 } from "./types.js";
 import { LazyCategoricalArray, has } from "./utils.js";
 
@@ -16,15 +17,15 @@ async function readSparse_010<S extends Readable>(
 	location: zarr.Group<S>,
 	key: string,
 	elem: zarr.Group<S> & Elem<S>,
-): Promise<SparseArray<zarr.NumberDataType>> {
+): Promise<SparseArray<zarr.NumberDataType, IndexType, S>> {
 	const shape = elem.attrs.shape as number[];
 	const format = elem.attrs["encoding-type"].slice(0, 3) as "csc" | "csr";
 	const indptr = (await zarr.open(elem.resolve("indptr"), {
 		kind: "array",
-	})) as zarr.Array<"int32", S>; // todo: allow 64
+	})) as zarr.Array<IndexType, S>;
 	const indices = (await zarr.open(elem.resolve("indices"), {
 		kind: "array",
-	})) as zarr.Array<"int32", S>; // todo: allow 64
+	})) as zarr.Array<IndexType, S>;
 	const data = (await zarr.open(elem.resolve("data"), {
 		kind: "array",
 	})) as zarr.Array<zarr.NumberDataType, S>;
@@ -86,7 +87,7 @@ type ReadFunctionVersioned = <S extends Readable>(
 ) =>
 	| AxisArrays<S>
 	| Promise<LazyCategoricalArray<UIntType, zarr.DataType, S>>
-	| Promise<SparseArray<zarr.NumberDataType>>;
+	| Promise<SparseArray<zarr.NumberDataType, IndexType, S>>;
 
 const IO_FUNC_REGISTRY_WITH_VERSION: {
 	[index: string]: ReadFunctionVersioned | undefined;
@@ -99,12 +100,11 @@ const IO_FUNC_REGISTRY_WITH_VERSION: {
 	"dataframe,0.2.0": readDict_010,
 };
 
-export async function readZarr<
-	S extends Readable,
-	D extends zarr.NumberDataType,
->(path: S): Promise<AnnData<S, D>> {
+export async function readZarr<S extends Readable>(
+	path: S,
+): Promise<AnnData<S, zarr.NumberDataType, IndexType>> {
 	const root = await zarr.open(path, { kind: "group" });
-	const adataInit = {} as AxisKeyTypes<S, D>;
+	const adataInit = {} as AxisKeyTypes<S, zarr.NumberDataType, IndexType>;
 	await Promise.all(
 		AxisKeys.map(async (k) => {
 			if ((k === "X" && (await has(root, k))) || k !== "X") {
@@ -120,13 +120,15 @@ export async function readElem<
 	K extends AxisKey,
 	R extends K extends Exclude<AxisKey, "X">
 		? AxisArrays<S>
-		: SparseArray<zarr.NumberDataType> | zarr.Array<zarr.NumberDataType, S>,
+		:
+				| SparseArray<zarr.NumberDataType, IndexType, S>
+				| zarr.Array<zarr.NumberDataType, S>,
 >(location: zarr.Group<S>, key: K): Promise<R>;
 export async function readElem<S extends Readable>(
 	location: zarr.Group<S>,
 	key: string,
 ): Promise<
-	| SparseArray<zarr.NumberDataType>
+	| SparseArray<zarr.NumberDataType, IndexType, S>
 	| LazyCategoricalArray<UIntType, zarr.DataType, S>
 	| zarr.Array<zarr.DataType, S>
 >;
@@ -134,7 +136,7 @@ export async function readElem<S extends Readable>(
 	location: zarr.Group<S>,
 	key: string,
 ): Promise<
-	| SparseArray<zarr.NumberDataType>
+	| SparseArray<zarr.NumberDataType, IndexType, S>
 	| LazyCategoricalArray<UIntType, zarr.DataType, S>
 	| zarr.Array<zarr.DataType, S>
 	| AxisArrays<S>

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,22 +19,24 @@ export type Slice = ReturnType<typeof zarr.slice>;
 export type AxisSelection = number | Slice | null;
 export type FullSelection = AxisSelection[];
 export type UIntType = zarr.Uint8 | zarr.Uint16 | zarr.Uint32;
+export type IndexType = zarr.Uint32; // TODO: | zarr.Uint64;
 export type ArrayType = Exclude<zarr.DataType, zarr.ObjectType>;
-export type BackedArray =
-	| zarr.Array<zarr.DataType, Readable>
-	| SparseArray<zarr.NumberDataType>
-	| LazyCategoricalArray<UIntType, zarr.DataType, Readable>
+export type BackedArray<S extends Readable> =
+	| zarr.Array<zarr.DataType, S>
+	| SparseArray<zarr.NumberDataType, IndexType, S>
+	| LazyCategoricalArray<UIntType, zarr.DataType, S>
 	| AxisArrays<Readable>;
 
 export interface AxisKeyTypes<
 	S extends Readable,
 	D extends zarr.NumberDataType,
+	I extends IndexType,
 > {
 	obs: AxisArrays<S>;
 	var: AxisArrays<S>;
 	obsm: AxisArrays<S>;
 	varm: AxisArrays<S>;
-	X: SparseArray<D> | zarr.Array<D, S> | undefined;
+	X: SparseArray<D, I, S> | zarr.Array<D, S> | undefined;
 	layers: AxisArrays<S>;
 	obsp: AxisArrays<S>;
 	varp: AxisArrays<S>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,7 +6,7 @@ import {
 } from "@zarrita/typedarray";
 import * as zarr from "zarrita";
 import type SparseArray from "./sparse_array.js";
-import type { FullSelection, Slice, UIntType } from "./types.js";
+import type { FullSelection, IndexType, Slice, UIntType } from "./types.js";
 
 const V2_STRING_REGEX = /v2:([US])(\d+)/;
 
@@ -68,27 +68,34 @@ function isLazyCategoricalArray<
 	K extends UIntType,
 	S extends Readable,
 >(
-	array: LazyCategoricalArray<K, L, S> | zarr.Array<L, S> | SparseArray<N>,
+	array:
+		| LazyCategoricalArray<K, L, S>
+		| zarr.Array<L, S>
+		| SparseArray<N, IndexType, S>,
 ): array is LazyCategoricalArray<K, L, S> {
-	return (array as LazyCategoricalArray<K, L, S>).categories !== undefined;
+	return "categories" in array;
 }
 
 function isSparseArray<
 	L extends zarr.DataType,
 	N extends zarr.NumberDataType,
+	I extends IndexType,
 	K extends UIntType,
 	S extends Readable,
 >(
-	array: LazyCategoricalArray<K, L, S> | zarr.Array<L, S> | SparseArray<N>,
-): array is SparseArray<N> {
-	return (array as SparseArray<N>).indptr !== undefined;
+	array:
+		| LazyCategoricalArray<K, L, S>
+		| zarr.Array<L, S>
+		| SparseArray<N, I, S>,
+): array is SparseArray<N, I, S> {
+	return "indptr" in array;
 }
 
 function isZarrBoolTypedArrayFromDtype(
 	data: Iterable<unknown>,
 	dtype: zarr.DataType,
 ): data is BoolArray {
-	return "get" in data !== undefined && dtype === "bool";
+	return "get" in data && dtype === "bool";
 }
 
 function isZarrStringTypedArrayFromDtype(
@@ -150,7 +157,10 @@ export async function get<
 	N extends zarr.NumberDataType,
 	K extends UIntType,
 	S extends Readable,
-	Arr extends LazyCategoricalArray<K, L, S> | zarr.Array<L, S> | SparseArray<N>,
+	Arr extends
+		| LazyCategoricalArray<K, L, S>
+		| zarr.Array<L, S>
+		| SparseArray<zarr.NumberDataType, IndexType, S>,
 >(
 	array: Arr,
 	selection: (null | Slice | number)[],
@@ -164,7 +174,10 @@ export async function get<
 	N extends zarr.NumberDataType,
 	K extends UIntType,
 	S extends Readable,
-	Arr extends LazyCategoricalArray<K, L, S> | zarr.Array<L, S> | SparseArray<N>,
+	Arr extends
+		| LazyCategoricalArray<K, L, S>
+		| zarr.Array<L, S>
+		| SparseArray<N, IndexType, S>,
 >(
 	array: Arr,
 	selection: number[],
@@ -178,7 +191,10 @@ export async function get<
 	N extends zarr.NumberDataType,
 	K extends UIntType,
 	S extends Readable,
-	Arr extends LazyCategoricalArray<K, L, S> | zarr.Array<L, S> | SparseArray<N>,
+	Arr extends
+		| LazyCategoricalArray<K, L, S>
+		| zarr.Array<L, S>
+		| SparseArray<N, IndexType, S>,
 >(array: Arr, selection: FullSelection) {
 	if (isLazyCategoricalArray(array)) {
 		const codes = await zarr.get(array.codes, selection);


### PR DESCRIPTION
And fix one more instance of https://typescript-eslint.io/rules/no-unnecessary-type-parameters/